### PR TITLE
feat: astro-font - optimize fonts & prevent CLS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "name": "nearshare-web",
       "dependencies": {
         "@iconify-json/fluent": "^1.1.45",
-        "@iconify-json/tabler": "^1.1.102"
+        "@iconify-json/tabler": "^1.1.102",
+        "astro-font": "^0.0.77"
       },
       "devDependencies": {
         "@astrojs/partytown": "^1.2.2",
@@ -1880,6 +1881,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
       }
+    },
+    "node_modules/astro-font": {
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/astro-font/-/astro-font-0.0.77.tgz",
+      "integrity": "sha512-dh5TX2uxwqdFq15DF9cbRZgEdE9o8q522MP6xZYs+rnd3dexfDsIJMeEIDNVO7rkRxwJ7sphhCqTmdWvUJaiDg=="
     },
     "node_modules/astro-icon": {
       "version": "1.0.1",
@@ -11178,6 +11184,11 @@
           }
         }
       }
+    },
+    "astro-font": {
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/astro-font/-/astro-font-0.0.77.tgz",
+      "integrity": "sha512-dh5TX2uxwqdFq15DF9cbRZgEdE9o8q522MP6xZYs+rnd3dexfDsIJMeEIDNVO7rkRxwJ7sphhCqTmdWvUJaiDg=="
     },
     "astro-icon": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@iconify-json/fluent": "^1.1.45",
-    "@iconify-json/tabler": "^1.1.102"
+    "@iconify-json/tabler": "^1.1.102",
+    "astro-font": "^0.0.77"
   }
 }

--- a/src/components/CustomStyles.astro
+++ b/src/components/CustomStyles.astro
@@ -1,13 +1,27 @@
 ---
-import '@fontsource/inter/variable.css';
+import { AstroFont } from "astro-font";
 
 // Nunito
 // Dosis
 ---
 
+<AstroFont
+  config={[
+    {
+      src: [],
+      preload: false,
+      display: "swap",
+      name: "InterVariable",
+      fallback: "sans-serif",
+      cssVariable: "aw-font-sans",
+      googleFontsURL:
+        "https://fonts.googleapis.com/css2?family=Inter:wght@100..900",
+    },
+  ]}
+/>
+
 <style is:inline is:global>
   :root {
-    --aw-font-sans: 'InterVariable';
     --aw-font-serif: var(--aw-font-sans);
     --aw-font-heading: var(--aw-font-sans);
 


### PR DESCRIPTION
Astro Font: https://www.launchfa.st/blog/building-astro-font

# Changes

This PR integrates `astro-font` which automatically generates the fallback font and pass it as the CSS Variable.